### PR TITLE
* Fixes for Tomcat 8.5

### DIFF
--- a/tomcat8/pom.xml
+++ b/tomcat8/pom.xml
@@ -56,7 +56,7 @@
 	</repositories>
 
 	<properties>
-		<tomcat.version>8.0.17</tomcat.version>
+		<tomcat.version>8.5.11</tomcat.version>
 	</properties>
 
 	<build>

--- a/tomcat8/src/main/java/org/bsworks/catalina/authenticator/openid/OpenIDAuthenticator.java
+++ b/tomcat8/src/main/java/org/bsworks/catalina/authenticator/openid/OpenIDAuthenticator.java
@@ -560,7 +560,7 @@ public class OpenIDAuthenticator
 	 * @see org.apache.catalina.authenticator.FormAuthenticator#authenticate(org.apache.catalina.connector.Request, javax.servlet.http.HttpServletResponse)
 	 */
 	@Override
-	public boolean authenticate(final Request request,
+	public boolean doAuthenticate(final Request request,
 			final HttpServletResponse response)
 		throws IOException {
 


### PR DESCRIPTION
The OpenID Authenticator didn't work for Tomcat 8.5. The required change was the same as for the OpenID Connect authenticator.